### PR TITLE
fix: ensure editor content renders on Linux/GTK environments

### DIFF
--- a/src/lib/editor/Editor.svelte
+++ b/src/lib/editor/Editor.svelte
@@ -1904,7 +1904,23 @@
 
     let createdEditor: MorayaEditor;
     try {
+      // Ensure the root element exists and is visible before creating the editor
+      if (!editorEl || !editorEl.parentElement) {
+        throw new Error('Editor root element not found in DOM');
+      }
+      editorEl.style.display = 'block';
+      editorEl.style.visibility = 'visible';
+
       createdEditor = await createEditor(editorOptions);
+
+      // Verify editor was actually created and has a view
+      if (!createdEditor || !createdEditor.view) {
+        throw new Error('Editor creation succeeded but view is missing');
+      }
+
+      // Force a DOM update to ensure content renders
+      await tick();
+      createdEditor.view.updateState(createdEditor.view.state);
     } catch (err) {
       console.error('[Editor] createEditor failed:', err);
       clearTimeout(readyTimeout);

--- a/src/lib/styles/editor.css
+++ b/src/lib/styles/editor.css
@@ -1,11 +1,23 @@
 /* Milkdown / ProseMirror editor styles */
 
+/* Ensure editor root is visible and can render content */
+.editor-root {
+  display: block;
+  visibility: visible;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background-color: var(--bg-primary);
+}
+
 .moraya-editor {
   outline: none;
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
   line-height: var(--line-height);
   color: var(--text-primary);
+  min-height: 100%;
 }
 
 /* Headings */


### PR DESCRIPTION
## Problem
Moraya displays a blank white screen on Linux with GTK/Wayland due to missing CSS visibility rules and missing DOM refresh after ProseMirror editor initialization.

## Root Cause
1. Editor root element not explicitly marked as visible after DOM insertion
2. Missing DOM refresh to trigger rendering after editor creation  
3. Missing CSS rules for editor root dimensions and visibility

## Solution
- Added explicit `display: block` and `visibility: visible` to editor root in Editor.svelte onMount
- Added `tick()` and state update after editor creation to force DOM refresh
- Added `.editor-root` CSS rules ensuring proper visibility, layout, and dimensions

## Changes
- `src/lib/editor/Editor.svelte`: Visibility checks and DOM refresh in onMount hook
- `src/lib/styles/editor.css`: New `.editor-root` CSS rules with explicit visibility and sizing

## Testing
- Tested on NixOS with Wayland/GTK
